### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 
 # SAML Extensions
 
-Libraries containing implementations of the SAML extensions defined in the [IDA Saml Profile]("https://www.gov.uk/government/publications/identity-assurance-hub-servi\
-ce-saml-20-profile"). Additionally it provides:
+Libraries containing implementations of the SAML extensions defined in the
+[IDA Saml Profile]("https://www.gov.uk/government/publications/identity-assurance-hub-service-saml-20-profile").
+Additionally it provides:
 
 * Bootstrapping of extensions into SAML environment
 * Test utilities for SAML extension classes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # SAML Extensions
 
 Libraries containing implementations of the SAML extensions defined in the
-[IDA Saml Profile]("https://www.gov.uk/government/publications/identity-assurance-hub-service-saml-20-profile").
+[IDA Saml Profile](https://www.gov.uk/government/publications/identity-assurance-hub-service-saml-20-profile).
 Additionally it provides:
 
 * Bootstrapping of extensions into SAML environment


### PR DESCRIPTION
The link was broken by the newline. Fixed it by putting the url all on one line.